### PR TITLE
adjusted standard name dew_point_temperature

### DIFF
--- a/bin/generate_gcoos_nc_timeseries_atm.py
+++ b/bin/generate_gcoos_nc_timeseries_atm.py
@@ -247,10 +247,10 @@ obs2.platform               = 'platform'
 obs2.instrument             = 'instrument'
 obs2.comment                = ''
 
-obs3                        = nc.createVariable('dew_point_tempearture','d',('time','timeSeries'),fill_value=-999.)
-obs3.long_name              = 'dew_point_tempearture'
-obs3.standard_name          = 'dew_point_tempearture'
-obs3.ncei_name              = 'dew_point_tempearture'
+obs3                        = nc.createVariable('dew_point_temperature','d',('time','timeSeries'),fill_value=-999.)
+obs3.long_name              = 'dew_point_temperature'
+obs3.standard_name          = 'dew_point_temperature'
+obs3.ncei_name              = 'dew_point_temperature'
 obs3.units                  = 'Celsius'
 obs3.scale_factor           = 1.
 obs3.add_offset             = 0.


### PR DESCRIPTION
The standard name for dew_point_temperature was spelled incorrectly (dew_point_tempearture) and caused a CF compliance error. I have made the change to the generate_gcoos_nc_timeseries_atm.py script.
