### PR TITLE
time variable not set appropriately

### DIFF
--- a/bin/generate_gcoos_nc_timeseries_atm.py
+++ b/bin/generate_gcoos_nc_timeseries_atm.py
@@ -380,7 +380,7 @@ for i in range(0,timeseries_length):
 
     time = cdftime.date2num(dateobj)
 
-    times[i] = time
+    times[i] = time*3600
 
     obs1[i] = data[i][2]
     obs2[i] = data[i][3]


### PR DESCRIPTION
I've been reviewing the time variable and I'm a little bit confused. In the code, you set the time variable to `cdftime = utime('hours since 1970-01-01 00:00:00')`. However, the units for the time variable are set as 
`times.units                 = 'seconds since 1970-01-01 00:00:00 UTC'`. 
Since the global attributes for the time range have been commented out
`#nc.time_coverage_start      = '00:00'
# nc.time_coverage_end        = '23:59' `

I cannot determine what the units are for the time and thus cannot interpret the time variable, which is crucial to understanding the data. 

After doing some digging and noticing your title 
`:title = "GCOOS 2016-11...` 
I think I can figure out what the problem is here. In order to convert your time variable to be in the units you list for time, we need to multiply the numbers by **3600** (1 hour = 3600 seconds). Which would give us the following values for the appropriate global attributes 
`nc.time_coverage_start      = '2015-11-01 00:04:59.999982'
nc.time_coverage_end        = '2015-11-30 23:35:00.000009'`

I've made the adjustment in your code at the point when you assign the values to the netCDF variable.
