### PR TITLE
include z attribute 'positive'

### DIFF
--- a/bin/generate_gcoos_nc_timeseries_atm.py
+++ b/bin/generate_gcoos_nc_timeseries_atm.py
@@ -179,6 +179,7 @@ z.long_name                 = "Altitude"
 z.standard_name             = "altitude"
 z.units                     = "m"
 z.axis                      = "Z"
+z.positive                  = "up"
 #z.valid_min                 = 0.0
 #z.valid_max                 = 0.0
 #z._FillValue                = fill_value=-999.


### PR DESCRIPTION
In order to understand which direction the z variable is, we define an attribute **positive** and assign it "up". In the case of a depth with increasing positive values as you descend, we would assign this attribute "down".
